### PR TITLE
Config implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__
+config.ini

--- a/ConvenienceFunctions/Omero_Images.py
+++ b/ConvenienceFunctions/Omero_Images.py
@@ -1,4 +1,5 @@
 # Omero-related imports
+from ctypes import alignment
 import omero
 from omero.gateway import BlitzGateway
 from omero.gateway import DatasetWrapper
@@ -36,12 +37,15 @@ class omero_images:
         password_entry.grid(row=1, column=1, padx=20, pady=10, sticky=tk.W)
         hostname_entry.grid(row=2, column=1, padx=20, pady=10, sticky=tk.W)
         port_entry.grid(row=3, column=1, padx=20, pady=10, sticky=tk.W)
-        config_button = tk.Button(pw_dialog, text="Save config", command=self.save_config)
-        config_button.grid(row=4, column=0, padx=20, pady=10)
-        close_button = tk.Button(pw_dialog, text="Close", command=pw_dialog.destroy)
-        close_button.grid(row=4, column=1, padx=20, pady=10)
-        
 
+        close_button = tk.Button(pw_dialog, text="OK", command=pw_dialog.destroy)
+        close_button.grid(row=4, column=0, padx=20, pady=10)
+
+        config_button = tk.Button(pw_dialog, text="save config", command=self.save_config)
+        config_button.place(x=265, y=174)
+
+        
+        
         pw_dialog.mainloop()
 
 

--- a/ConvenienceFunctions/Omero_Images.py
+++ b/ConvenienceFunctions/Omero_Images.py
@@ -14,7 +14,7 @@ import os
 class omero_images:
 
     def __init__(self):
-        pass
+        self.password_val = ""
         #self.dataset_id = tk.StringVar(self.buttonframe, value="5569")
 
     def login_omero(self):
@@ -24,11 +24,12 @@ class omero_images:
             config['OMERO']["hostname"] = self.hostname.get()
             config['OMERO']["username"] = self.username.get()
             config['OMERO']["port"]     = self.port.get()
+            self.password_val           = self.password.get()
             pw_dialog.destroy()
 
         pw_dialog = tk.Tk()
         self.username = tk.StringVar(pw_dialog, value=config['OMERO']["username"])
-        self.password = tk.StringVar(pw_dialog, value="")
+        self.password = tk.StringVar(pw_dialog, value=self.password_val)
         self.hostname = tk.StringVar(pw_dialog, value=config['OMERO']["hostname"])
         self.port     = tk.StringVar(pw_dialog, value=config['OMERO']["port"])
         username_label = tk.Label(pw_dialog, text="Username").grid(row=0, padx=20, pady=10, sticky=tk.W)

--- a/ConvenienceFunctions/Omero_Images.py
+++ b/ConvenienceFunctions/Omero_Images.py
@@ -20,6 +20,12 @@ class omero_images:
     def login_omero(self):
         """Opens GUI to collect login info."""
 
+        def destroy():
+            config['OMERO']["hostname"] = self.hostname.get()
+            config['OMERO']["username"] = self.username.get()
+            config['OMERO']["port"]     = self.port.get()
+            pw_dialog.destroy()
+
         pw_dialog = tk.Tk()
         self.username = tk.StringVar(pw_dialog, value=config['OMERO']["username"])
         self.password = tk.StringVar(pw_dialog, value="")
@@ -38,13 +44,11 @@ class omero_images:
         hostname_entry.grid(row=2, column=1, padx=20, pady=10, sticky=tk.W)
         port_entry.grid(row=3, column=1, padx=20, pady=10, sticky=tk.W)
 
-        close_button = tk.Button(pw_dialog, text="OK", command=pw_dialog.destroy)
+        close_button = tk.Button(pw_dialog, text="OK", command=destroy)
         close_button.grid(row=4, column=0, padx=20, pady=10)
 
         config_button = tk.Button(pw_dialog, text="save config", command=self.save_config)
-        config_button.place(x=265, y=174)
-
-        
+        config_button.place(x=265, y=174)        
         
         pw_dialog.mainloop()
 

--- a/ConvenienceFunctions/Omero_Images.py
+++ b/ConvenienceFunctions/Omero_Images.py
@@ -296,7 +296,7 @@ def write_config():
 config = configparser.ConfigParser()
 if not os.path.exists(CONFIG_FPATH):
     config['OMERO'] = {'hostname': 'omero-imaging.uni-muenster.de', 'username': '', "port":4064}
-    config['N2V'] =   {'n_epoch': '100', 'dataset_id':""}
+    config['N2V'] =   {'n_epoch': '100', 'dataset_id':"", "batch_size":"32"}
     write_config()
 else:
     # Read File

--- a/N2V/N2V_GUI_OMERO_v2.py
+++ b/N2V/N2V_GUI_OMERO_v2.py
@@ -159,7 +159,7 @@ class GUI:
         empty_image = np.zeros(image.shape)
         self.a.imshow(image, cmap='magma')
         self.canvas.draw()
-        self.b.imshow(empty_image, cmap='magma')
+        self.b.imshow(empty_image, cmap='magma', vmin=0, vmax=1)
         self.canvas.draw()
 
 

--- a/N2V/N2V_GUI_OMERO_v2.py
+++ b/N2V/N2V_GUI_OMERO_v2.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 from n2v.models import N2VConfig, N2V
 from n2v.internals.N2V_DataGenerator import N2V_DataGenerator
 import os
+import sys
 from tkinter import filedialog, simpledialog
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 import tensorflow as tf
@@ -17,6 +18,7 @@ import omero
 from omero.gateway import BlitzGateway
 import getpass
 
+sys.path.append("../ConvenienceFunctions")
 from Omero_Images import omero_images
 
 

--- a/N2V/N2V_GUI_OMERO_v2.py
+++ b/N2V/N2V_GUI_OMERO_v2.py
@@ -43,6 +43,7 @@ class GUI:
         # StringVars that can be inserted by User
         self.model_name = tk.StringVar(self.buttonframe, value="my_model")
         self.train_epochs = tk.StringVar(self.buttonframe, value=config['N2V']["n_epoch"])
+        self.train_batchsize = tk.StringVar(self.buttonframe, value=config['N2V']["batch_size"])
         self.dataset_id = tk.StringVar(self.buttonframe, value=config['N2V']["dataset_id"])
 
         #Selection box for image dimensions
@@ -64,6 +65,8 @@ class GUI:
         self.insert_model_name = tk.Entry(self.buttonframe, textvariable=self.model_name).grid(row=2, column=3, padx=10, pady=10, sticky=tk.W)
         self.label2 = tk.Label(self.buttonframe, text="Number of training epochs").grid(row=3, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
         self.insert_train_epochs = tk.Entry(self.buttonframe, textvariable=self.train_epochs).grid(row=3, column=3, padx=10, pady=10, sticky=tk.W)
+        self.label3 = tk.Label(self.buttonframe, text="Batch size").grid(row=4, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
+        self.insert_train_batchsize = tk.Entry(self.buttonframe, textvariable=self.train_batchsize).grid(row=4, column=3, padx=10, pady=10, sticky=tk.W)
         self.start_training = tk.Button(self.buttonframe, text="Start training", command=self.start_training)
         self.start_training.grid(row=5, column=1, padx=30, pady=10, sticky=tk.E)
         self.preview_result_button = tk.Button(self.buttonframe, text="Preview Result", command=self.preview_image, state=tk.DISABLED)
@@ -224,19 +227,22 @@ class GUI:
         try:
             epochs = int(self.train_epochs.get())
         except ValueError:
-            tk.messagebox.showwarning(title="Wrong entry", message="Please enter a number!")
+            tk.messagebox.showwarning(title="Wrong entry", message="Please enter a number for epochs!")
             train_steps=0
             epochs=0
+
+        try:
+            train_batch_size = int(self.train_batchsize.get())
+        except ValueError:
+            tk.messagebox.showwarning(title="Wrong entry", message="Please enter a number for the batch size!")
+            train_steps=0
+            train_batch_size=0
 
         shapes = []
         for i in range(len(self.imgs)):
             shapes.append(self.imgs[i].shape[1])
-        if self.three_D:
-            train_batch_size = 8
-        else:
-            train_batch_size = 32
 
-        if epochs > 0:
+        if (epochs > 0) and (train_batch_size > 0):
             patch_shape = self.generate_patches()
             train_steps = int(self.X.shape[0]/train_batch_size)
 

--- a/N2V/N2V_GUI_OMERO_v2.py
+++ b/N2V/N2V_GUI_OMERO_v2.py
@@ -19,7 +19,7 @@ from omero.gateway import BlitzGateway
 import getpass
 
 sys.path.append("../ConvenienceFunctions")
-from Omero_Images import omero_images
+from Omero_Images import omero_images, config
 
 
 class GUI:
@@ -42,8 +42,8 @@ class GUI:
 
         # StringVars that can be inserted by User
         self.model_name = tk.StringVar(self.buttonframe, value="my_model")
-        self.train_epochs = tk.StringVar(self.buttonframe, value=100)
-        self.dataset_id = tk.StringVar(self.buttonframe, value="5569")
+        self.train_epochs = tk.StringVar(self.buttonframe, value=config['N2V']["n_epoch"])
+        self.dataset_id = tk.StringVar(self.buttonframe, value=config['N2V']["dataset_id"])
 
         #Selection box for image dimensions
         self.label6 = tk.Label(self.buttonframe, text="")

--- a/N2V/N2V_GUI_OMERO_v2.py
+++ b/N2V/N2V_GUI_OMERO_v2.py
@@ -45,6 +45,12 @@ class GUI:
         self.train_epochs = tk.StringVar(self.buttonframe, value=config['N2V']["n_epoch"])
         self.train_batchsize = tk.StringVar(self.buttonframe, value=config['N2V']["batch_size"])
         self.dataset_id = tk.StringVar(self.buttonframe, value=config['N2V']["dataset_id"])
+        patch_opt = list(2**np.arange(5,11)) # Gives patch size option in the powers of 2
+        patch_size = config['N2V']["patch_size"]
+        if int(patch_size) not in patch_opt:
+            print("Invalid patch size, setting to default 256x256")
+            patch_size = 256
+        self.train_patchsize = tk.StringVar(self.buttonframe, value=patch_size)
 
         #Selection box for image dimensions
         self.label6 = tk.Label(self.buttonframe, text="")
@@ -63,16 +69,20 @@ class GUI:
         # Training Buttons
         self.label1 = tk.Label(self.buttonframe, text="Save model as:").grid(row=2, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
         self.insert_model_name = tk.Entry(self.buttonframe, textvariable=self.model_name).grid(row=2, column=3, padx=10, pady=10, sticky=tk.W)
-        self.label2 = tk.Label(self.buttonframe, text="Number of training epochs").grid(row=3, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
-        self.insert_train_epochs = tk.Entry(self.buttonframe, textvariable=self.train_epochs).grid(row=3, column=3, padx=10, pady=10, sticky=tk.W)
-        self.label3 = tk.Label(self.buttonframe, text="Batch size").grid(row=4, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
-        self.insert_train_batchsize = tk.Entry(self.buttonframe, textvariable=self.train_batchsize).grid(row=4, column=3, padx=10, pady=10, sticky=tk.W)
+
+        self.label5 = tk.Label(self.buttonframe, text="Patch size").grid(row=3, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
+        self.patchsize_dropdown = tk.OptionMenu(self.buttonframe, self.train_patchsize, *patch_opt).grid(row=3, column=3, padx=10, pady=10, sticky=tk.W)
+        
+        self.label2 = tk.Label(self.buttonframe, text="Number of training epochs").grid(row=4, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
+        self.insert_train_epochs = tk.Entry(self.buttonframe, textvariable=self.train_epochs).grid(row=4, column=3, padx=10, pady=10, sticky=tk.W)
+        self.label3 = tk.Label(self.buttonframe, text="Batch size").grid(row=5, column=1, columnspan=2, padx=10, pady=10, sticky=tk.E)
+        self.insert_train_batchsize = tk.Entry(self.buttonframe, textvariable=self.train_batchsize).grid(row=5, column=3, padx=10, pady=10, sticky=tk.W)
         self.start_training = tk.Button(self.buttonframe, text="Start training", command=self.start_training)
-        self.start_training.grid(row=5, column=1, padx=30, pady=10, sticky=tk.E)
+        self.start_training.grid(row=6, column=1, padx=30, pady=10, sticky=tk.E)
         self.preview_result_button = tk.Button(self.buttonframe, text="Preview Result", command=self.preview_image, state=tk.DISABLED)
-        self.preview_result_button.grid(row=5, column=2, padx=30, pady=10, sticky=tk.E)
+        self.preview_result_button.grid(row=6, column=2, padx=30, pady=10, sticky=tk.E)
         self.plot_loss_button = tk.Button(self.buttonframe, text="Plot loss", command=self.plot_loss, state=tk.DISABLED)
-        self.plot_loss_button.grid(row=5, column=3, padx=30, pady=10, sticky=tk.E)
+        self.plot_loss_button.grid(row=6, column=3, padx=30, pady=10, sticky=tk.E)
 
         # Prediction Buttons
         self.label4 = tk.Label(self.buttonframe, text="Use trained model for prediction:")
@@ -208,13 +218,13 @@ class GUI:
 
 
     def set_patch_shape(self):
-        """Sets patch shape. If 3D: (4, 256, 256), else (256, 256).
+        """Sets patch shape. If 3D: (4, train_patchsize, train_patchsize), else (train_patchsize, train_patchsize).
         Optimized for images with size 512x512"""
-
+        patch_size = int(self.train_patchsize.get())
         if self.three_D:
-            patch_shape = (4, 256, 256)
+            patch_shape = (4, patch_size, patch_size)
         else:
-            patch_shape = (256, 256)
+            patch_shape = (patch_size, patch_size)
 
         return patch_shape
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,24 @@ Interactive GUI to train and apply the DeepLearningTool Noise2Void for image den
 
 The GUI implements the original N2V code by Krull et al., Noise2Void - Learning Denoising from Single Noisy Images (https://arxiv.org/abs/1811.10980)
 Source code: https://github.com/juglab/N2V_fiji/
+
+## Installation
+
+```shell
+conda create -n n2v python=3.7
+conda activate n2v
+```
+
+With GPU
+```shell
+conda install tensorflow-gpu=2.4.1 keras=2.3.1
+pip install n2v omero-py
+```
+
+Aleternative: With CPU only
+```shell
+pip install tensorflow==2.4 keras=2.3.1
+pip install n2v omero-py
+```
+
+More details on the installation of N2V in [here](https://github.com/juglab/n2v)


### PR DESCRIPTION
Here are the modifications we talked about:
* Added the config file to prefill the login options. Can be used for other fields (see how I can also input the dataset ID for N2V)
* Updated the README with installation instructions and a link to the N2V project
* import linking to the ConvenienceFunction outside of the N2V package.  Note that this is a bit hacky, and works only if you run N2V_GUI_OMERO_v2.py from the N2V folder (see https://stackoverflow.com/a/50193944 for an alternative)

Additionally: 
* Fixed a bug (after loading an image, hovering the mouse over the empty image was plotting a looong list of zeros)
* Added a gitignore for the python cache folders and the config file that shouldn't be tracked (default config is hardcoded)